### PR TITLE
fix doc ionic vue

### DIFF
--- a/src/pages/vue/ionic.mdx
+++ b/src/pages/vue/ionic.mdx
@@ -34,7 +34,7 @@ Create a `src/App.css` file with the following content to include Tailwind CSS:
 ```css
 @import 'tailwindcss';
 /* import Konsta UI theme */
-@import 'konsta/react/theme.css';
+@import 'konsta/vue/theme.css';
 ```
 
 ## KonstaProvider


### PR DESCRIPTION
This PR fixes a typo where the React lib was used in the vue exemple